### PR TITLE
PeppolMLSBuilder: fix PeppolMLSLineResponseBuilder built too quickly in createForValidationResultList method

### DIFF
--- a/peppol-mls/src/main/java/com/helger/peppol/mls/PeppolMLSBuilder.java
+++ b/peppol-mls/src/main/java/com/helger/peppol/mls/PeppolMLSBuilder.java
@@ -760,7 +760,7 @@ public class PeppolMLSBuilder implements IBuilder <ApplicationResponseType>
     final ICommonsMap <String, PeppolMLSLineResponseBuilder> aBuilderMap = new CommonsHashMap <> ();
     aVRL.forEachFlattened (aError -> {
       // Single error or warning?
-      var ret = aBuilderMap.computeIfAbsent(aError.getErrorFieldName(), k -> new PeppolMLSLineResponseBuilder().errorField(k))
+      final PeppolMLSLineResponseBuilder ret = aBuilderMap.computeIfAbsent(aError.getErrorFieldName(), k -> new PeppolMLSLineResponseBuilder().errorField(k))
               .addResponse(new PeppolMLSLineResponseResponseBuilder().statusReasonCode(aError.isError() ?
                               EPeppolMLSStatusReasonCode.BUSINESS_RULE_VIOLATION_FATAL
                               : EPeppolMLSStatusReasonCode.BUSINESS_RULE_VIOLATION_WARNING)

--- a/peppol-mls/src/main/java/com/helger/peppol/mls/PeppolMLSBuilder.java
+++ b/peppol-mls/src/main/java/com/helger/peppol/mls/PeppolMLSBuilder.java
@@ -760,16 +760,14 @@ public class PeppolMLSBuilder implements IBuilder <ApplicationResponseType>
     final ICommonsMap <String, PeppolMLSLineResponseBuilder> aBuilderMap = new CommonsHashMap <> ();
     aVRL.forEachFlattened (aError -> {
       // Single error or warning?
-      aBuilderMap.computeIfAbsent (aError.getErrorFieldName (), k -> {
-        final PeppolMLSLineResponseBuilder ret = new PeppolMLSLineResponseBuilder ().errorField (k);
-        aMLSBuilder.addLineResponse (ret);
-        return ret;
-      })
-                 .addResponse (new PeppolMLSLineResponseResponseBuilder ().statusReasonCode (aError.isError () ? EPeppolMLSStatusReasonCode.BUSINESS_RULE_VIOLATION_FATAL
-                                                                                                               : EPeppolMLSStatusReasonCode.BUSINESS_RULE_VIOLATION_WARNING)
-                                                                          .description (StringHelper.getConcatenatedOnDemand (aError.getErrorID (),
-                                                                                                                              " - ",
-                                                                                                                              aError.getErrorText (aDisplayLocale))));
+      var ret = aBuilderMap.computeIfAbsent(aError.getErrorFieldName(), k -> new PeppolMLSLineResponseBuilder().errorField(k))
+              .addResponse(new PeppolMLSLineResponseResponseBuilder().statusReasonCode(aError.isError() ?
+                              EPeppolMLSStatusReasonCode.BUSINESS_RULE_VIOLATION_FATAL
+                              : EPeppolMLSStatusReasonCode.BUSINESS_RULE_VIOLATION_WARNING)
+                      .description(StringHelper.getConcatenatedOnDemand(aError.getErrorID(),
+                              " - ",
+                              aError.getErrorText(aDisplayLocale))));
+      aMLSBuilder.addLineResponse(ret);
     });
     return aMLSBuilder;
   }


### PR DESCRIPTION
Hello,

The `createForValidationResultList` method in `PeppolMLSBuilder` is not working properly, as the builder used to create the lines for each error is built too soon:  `aMLSBuilder.addLineResponse (ret)` calls the `build()` method of the parameter `ret`, but at that point it is not complete yet (missing the response part), and so it throws an `IllegalArgumentException`.

This PR ensures that we add the line in the `aMLSBuilder`  only when the response is set.